### PR TITLE
ci: add project stage sync workflow

### DIFF
--- a/.github/workflows/project-stage-sync.yml
+++ b/.github/workflows/project-stage-sync.yml
@@ -21,12 +21,11 @@ jobs:
       PROJECT_ID: PVT_kwHOA9QND84BF1Am
       STAGE_FIELD_NAME: Stage
       STATUS_FIELD_NAME: Status
-      PROJECT_AUTOMATION_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
     steps:
       - name: Sync project stage with status
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.PROJECT_AUTOMATION_TOKEN != '' && env.PROJECT_AUTOMATION_TOKEN || github.token }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN != '' && secrets.PROJECT_AUTOMATION_TOKEN || github.token }}
           script: |
             const PROJECT_ID = process.env.PROJECT_ID;
             const STAGE_FIELD_NAME = process.env.STAGE_FIELD_NAME;


### PR DESCRIPTION
## Summary
- add scheduled + event-driven workflow to sync project Stage from Status
- allow optional PAT fallback when project permissions needed

## Testing
- not run (workflow syntax only)

Closes #13.
