### PR TITLE
docs: describe project automation runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Proxmox OpenAPI Tooling
+
+Utilities for scraping the official Proxmox API viewer, normalizing responses, and publishing OpenAPI specs plus a companion SPA.
+
+## Packages
+- `app/`: Vite-based SPA that surfaces the generated specifications.
+- `tools/`: CLI packages for scraping, normalization, OpenAPI generation, and automation helpers.
+- `.github/workflows/`: CI pipelines for validations, artifact generation, GitHub Pages, and project automation.
+
+## Working With Automation
+The "Project Stage Sync" workflow keeps the delivery project up to date. Review the [automation runbook](docs/automation.md) for triggers, token requirements, and manual override instructions. When opening a pull request, ensure the relevant issue is linked so the workflow can reconcile status changes.
+
+## Contributing
+1. Install dependencies with `npm install`.
+2. Run targeted checks (`npm run lint`, `npm run test:all`, etc.) before pushing.
+3. Reference the linked issue in branch names/PR bodies and document any automation impact.
+4. See [docs/automation.md](docs/automation.md) for expectations around project updates and troubleshooting.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,23 @@
+# Project Automation Runbook
+
+This document describes the GitHub automation that keeps the Proxmox OpenAPI delivery board in sync, plus the fallback steps when human intervention is required.
+
+## Stage Sync Workflow
+- **Location:** `.github/workflows/project-stage-sync.yml`
+- **Purpose:** Align the "Stage" single-select on Project #4 with each item's Status so the board reflects real progress.
+- **Triggers:** Hourly cron, manual `workflow_dispatch`, issue activity, and `project_card` events (created/edited).
+- **Token usage:** The job requests `repository-projects: write`. It prefers the `PROJECT_AUTOMATION_TOKEN` secret for broader scopes and automatically falls back to the default `GITHUB_TOKEN` when the PAT is absent.
+- **Beta handling:** Issues attached to milestones containing "beta" are promoted to the Beta stage even if Status is still "In Progress".
+
+## Manual Overrides
+If automation is paused or lacks access, update Stage manually for affected items:
+1. Open the project item in GitHub (Project #4, "Proxmox OpenAPI Delivery").
+2. Set the Status column to the desired value. When the workflow resumes, it will reconcile Stage automatically.
+3. For urgent fixes, run the workflow manually (`Actions` → `Project Stage Sync` → `Run workflow`).
+4. Should an item need to bypass automation (e.g., experimental branches), pin the desired Stage and leave a comment on the issue explaining why; revisit once the condition clears.
+
+## Troubleshooting
+- **Workflow permissions:** Ensure `PROJECT_AUTOMATION_TOKEN` is defined with `project` scope if the default token cannot write project fields.
+- **Audit logs:** Workflow logs show each item updated (`Updated Stage for #<number>`). Use `toJSON` helpers or add local logging inside the script for deeper debugging.
+- **Rate limits:** The job processes the first 100 items per run. If the project grows, adjust the query pagination (`items(first: ...)`).
+- **Rollback:** If a bad update lands, revert by re-running the workflow after correcting Status, or manually set Stage to the expected value following the steps above.


### PR DESCRIPTION
## Summary
- add automation runbook documenting the project stage sync workflow
- create a repository README pointing contributors to the automation guidance

## Testing
- not run (documentation only)

Closes #12.
