### PR TITLE
docs: add action release checklist

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -21,3 +21,31 @@ If automation is paused or lacks access, update Stage manually for affected item
 - **Audit logs:** Workflow logs show each item updated (`Updated Stage for #<number>`). Use `toJSON` helpers or add local logging inside the script for deeper debugging.
 - **Rate limits:** The job processes the first 100 items per run. If the project grows, adjust the query pagination (`items(first: ...)`).
 - **Rollback:** If a bad update lands, revert by re-running the workflow after correcting Status, or manually set Stage to the expected value following the steps above.
+
+## GitHub Action Release Checklist
+Use this checklist whenever you cut a new release of the Proxmox OpenAPI artifacts action. The workflow at
+`.github/workflows/action-release.yml` automates most chores, but manual verification keeps the archive-only
+distribution trustworthy.
+
+1. **Prep the workspace**
+   - Ensure `main` contains the latest changes destined for the release.
+   - Run `npm run action:package` to rebuild `.github/actions/proxmox-openapi-artifacts/dist` locally.
+   - Commit the updated dist output, README changes, and changelog entry with a semantic tag (e.g. `feat(action):`).
+
+2. **Tag and publish**
+   - Create an annotated tag matching the release (e.g. `git tag -a v1.0.0 -m "Proxmox OpenAPI action v1.0.0"`).
+   - Push the tag (`git push origin v1.0.0`). This triggers the `action-release` workflow which rebuilds dist, packages
+     `.tgz` and `.zip` bundles, and uploads assets to the GitHub release.
+
+3. **Validate artifacts**
+   - Download the uploaded archives and verify they unpack to `proxmox-openapi-artifacts-action/action.yml` + `dist/`.
+   - Optionally smoke-test locally by running the action from the unpacked folder using `node dist/index.cjs` with the
+     same environment variables the workflow uses.
+
+4. **Update docs**
+   - Confirm `README.md` usage instructions reference the new version tag.
+   - Append a changelog entry describing notable changes since the last release.
+
+5. **Self-hosted distribution**
+   - For environments without marketplace access, publish the `.tgz` link and instructions (see README snippet) so users
+     can fetch and unpack the archive into their repositories.


### PR DESCRIPTION
## Summary
- add a GitHub Action release checklist to docs/automation.md covering packaging, tagging, and verification
- reinforce README guidance indirectly by documenting the published workflow

## Testing
- npm run lint

Closes #4