### PR TITLE
fix: align npm package tsconfig

### DIFF
--- a/packages/proxmox-openapi/tsconfig.json
+++ b/packages/proxmox-openapi/tsconfig.json
@@ -2,11 +2,19 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "../../",
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "composite": true
   },
-  "include": ["src"]
+  "include": [
+    "src",
+    "../../tools/api-scraper/src",
+    "../../tools/api-normalizer/src",
+    "../../tools/openapi-generator/src",
+    "../../tools/automation/src",
+    "../../tools/shared"
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust the npm package tsconfig so TypeScript can resolve workspace dependencies during type checking
- expand the include set to cover shared tooling sources, fixing the automation pipeline build

## Testing
- npm run lint
- npm run test:all

Relates to #7