### PR TITLE
fix: unblock tsup declaration build

### DIFF
--- a/packages/proxmox-openapi/package.json
+++ b/packages/proxmox-openapi/package.json
@@ -9,9 +9,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./cli": {
       "import": "./dist/cli.mjs",

--- a/packages/proxmox-openapi/tsconfig.tsup.json
+++ b/packages/proxmox-openapi/tsconfig.tsup.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": false
+  }
+}

--- a/packages/proxmox-openapi/tsup.config.ts
+++ b/packages/proxmox-openapi/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
     clean: true,
     outDir: "dist",
     target: "node18",
+    tsconfig: "tsconfig.tsup.json",
   },
   {
     entry: { cli: "src/cli.ts" },
@@ -17,6 +18,7 @@ export default defineConfig([
     clean: false,
     outDir: "dist",
     target: "node18",
+    tsconfig: "tsconfig.tsup.json",
     banner: {
       js: "#!/usr/bin/env node",
     },


### PR DESCRIPTION
## Summary
- add a tsup-scoped TS config that disables composite mode so declarations emit cleanly
- point both tsup builds at the relaxed config and silence the conditional export warning

## Testing
- npm run build --workspace packages/proxmox-openapi

Fixes #31