### PR TITLE
fix: align npm package release payload with v2.2.5

### DIFF
--- a/.github/workflows/openapi-release.yml
+++ b/.github/workflows/openapi-release.yml
@@ -44,7 +44,8 @@ jobs:
           set -euo pipefail
           npm run openapi:release:prepare -- "${RELEASE_TAG}"
           STAGING_DIR="var/openapi-release/proxmox-openapi-schema-${RELEASE_TAG}"
-          npm run automation:summary -- --input var/automation-summary.json --output "${STAGING_DIR}/AUTOMATION_SUMMARY.md" --relative-to "${STAGING_DIR}"
+          RELEASE_NOTES_PATH="var/openapi-release/RELEASE_NOTES-${RELEASE_TAG}.md"
+          test -f "${RELEASE_NOTES_PATH}"
           (cd var/openapi-release && tar -czf "proxmox-openapi-schema-${RELEASE_TAG}.tgz" "proxmox-openapi-schema-${RELEASE_TAG}")
           (cd var/openapi-release && zip -r "proxmox-openapi-schema-${RELEASE_TAG}.zip" "proxmox-openapi-schema-${RELEASE_TAG}")
 
@@ -53,15 +54,11 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Proxmox OpenAPI ${{ github.ref_name }}
-          body_path: var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/RELEASE_NOTES.md
+          body_path: var/openapi-release/RELEASE_NOTES-${{ github.ref_name }}.md
           files: |
             var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}.tgz
             var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}.zip
-            var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/proxmox-ve.json
-            var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/proxmox-ve.yaml
             var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/openapi.sha256.json
-            var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/automation-summary.json
-            var/openapi-release/proxmox-openapi-schema-${{ github.ref_name }}/AUTOMATION_SUMMARY.md
           draft: false
           prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
           fail_on_unmatched_files: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "proxmox-openapi",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "GPL-3.0",
       "workspaces": [
         ".github/actions/proxmox-openapi-artifacts",
         "packages/proxmox-openapi",
@@ -6729,8 +6729,8 @@
     },
     "packages/proxmox-openapi": {
       "name": "@mihailfox/proxmox-openapi",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "2.2.5",
+      "license": "GPL-3.0",
       "dependencies": {
         "@proxmox-openapi/automation": "0.1.0",
         "commander": "^12.1.0"

--- a/packages/proxmox-openapi/package.json
+++ b/packages/proxmox-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mihailfox/proxmox-openapi",
-  "version": "0.1.0",
+  "version": "2.2.5",
   "description": "CLI and library for generating Proxmox OpenAPI artifacts.",
   "type": "module",
   "private": false,

--- a/scripts/prepare-openapi-release.mjs
+++ b/scripts/prepare-openapi-release.mjs
@@ -9,8 +9,6 @@ const workspace = process.cwd();
 const artifactsDir = path.resolve("var", "openapi");
 const releaseRoot = path.resolve("var", "openapi-release");
 const stagingDir = path.join(releaseRoot, `proxmox-openapi-schema-${tagName}`);
-const automationSummaryPath = path.resolve("var", "automation-summary.json");
-
 async function main() {
   await fs.rm(stagingDir, { recursive: true, force: true });
   await fs.mkdir(stagingDir, { recursive: true });
@@ -25,9 +23,7 @@ async function main() {
   await writeJson(path.join(stagingDir, "openapi.sha256.json"), manifest);
 
   const releaseNotes = await composeReleaseNotes(tagName);
-  await fs.writeFile(path.join(stagingDir, "RELEASE_NOTES.md"), releaseNotes, "utf8");
-
-  await copyIfExists(automationSummaryPath, path.join(stagingDir, "automation-summary.json"));
+  await fs.writeFile(path.join(releaseRoot, `RELEASE_NOTES-${tagName}.md`), releaseNotes, "utf8");
 
   console.log(`[openapi-release] Prepared bundle at ${path.relative(workspace, stagingDir)}.`);
 }
@@ -114,7 +110,7 @@ async function readWorkingState() {
 
 async function readAutomationSummary() {
   try {
-    return JSON.parse(await fs.readFile(automationSummaryPath, "utf8"));
+    return JSON.parse(await fs.readFile(path.resolve("var", "automation-summary.json"), "utf8"));
   } catch {
     return null;
   }
@@ -150,15 +146,6 @@ async function readStateAtRef(ref) {
 
 function runGitShow(ref, file) {
   return execSync(`git show ${ref}:${file}`, { encoding: "utf8" });
-}
-
-async function copyIfExists(source, target) {
-  try {
-    await fs.access(source);
-    await fs.copyFile(source, target);
-  } catch {
-    // optional file
-  }
 }
 
 async function writeJson(filePath, payload) {


### PR DESCRIPTION
## Summary
- bump `@mihailfox/proxmox-openapi` to v2.2.5 so the npm package matches the latest schema release
- stop publishing redundant automation summary and raw schema assets; keep them only inside the bundled archives while retaining the checksum manifest
- relocate release notes outside the schema archive so the tar/zip contain only the JSON, YAML, and checksum manifest

## Testing
- npm run typecheck
- npm run build --workspace packages/proxmox-openapi

Fixes #36