### PR TITLE
fix: normalize release tag handling in workflows

### DIFF
--- a/.github/workflows/action-release.yml
+++ b/.github/workflows/action-release.yml
@@ -33,16 +33,16 @@ jobs:
           fi
           RELEASE_VERSION="$(
             node -e '
-const tag = process.env.RELEASE_TAG ?? "";
-if (!tag) throw new Error("missing tag");
-const stripped = tag.replace(/^v/i, "");
-if (!stripped) throw new Error(`unable to derive version from tag "${tag}"`);
-const normalized = stripped.replace(/\.([0-9A-Za-z-]+)\./, "-$1.");
-if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
-  throw new Error(`unsupported release tag "${tag}" -> "${normalized}"`);
-}
-process.stdout.write(normalized);
-' 2>/tmp/action-release-version.err
+          const tag = process.env.RELEASE_TAG ?? "";
+          if (!tag) throw new Error("missing tag");
+          const stripped = tag.replace(/^v/i, "");
+          if (!stripped) throw new Error(`unable to derive version from tag "${tag}"`);
+          const normalized = stripped.replace(/\.([0-9A-Za-z-]+)\./, "-$1.");
+          if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
+            throw new Error(`unsupported release tag "${tag}" -> "${normalized}"`);
+          }
+          process.stdout.write(normalized);
+          ' 2>/tmp/action-release-version.err
           )" || {
             cat /tmp/action-release-version.err >&2
             exit 1
@@ -59,10 +59,15 @@ process.stdout.write(normalized);
           tar -czf "var/action-bundle/proxmox-openapi-artifacts-action-${NORMALIZED_TAG}.tgz" -C var/action-bundle proxmox-openapi-artifacts-action
           (cd var/action-bundle && zip -r "proxmox-openapi-artifacts-action-${NORMALIZED_TAG}.zip" proxmox-openapi-artifacts-action)
           echo "NORMALIZED_TAG=${NORMALIZED_TAG}" >> $GITHUB_ENV
+          tar -czf "var/action-bundle/proxmox-openapi-artifacts-action-${NORMALIZED_TAG}.tgz" -C var/action-bundle proxmox-openapi-artifacts-action
+          (cd var/action-bundle && zip -r "proxmox-openapi-artifacts-action-${NORMALIZED_TAG}.zip" proxmox-openapi-artifacts-action)
+          echo "NORMALIZED_TAG=${NORMALIZED_TAG}" >> $GITHUB_ENV
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            var/action-bundle/proxmox-openapi-artifacts-action-${{ env.NORMALIZED_TAG }}.tgz
+            var/action-bundle/proxmox-openapi-artifacts-action-${{ env.NORMALIZED_TAG }}.zip
             var/action-bundle/proxmox-openapi-artifacts-action-${{ env.NORMALIZED_TAG }}.tgz
             var/action-bundle/proxmox-openapi-artifacts-action-${{ env.NORMALIZED_TAG }}.zip
         env:

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -46,20 +46,20 @@ jobs:
           fi
           RELEASE_VERSION="$(
             node -e '
-const tag = process.env.RELEASE_TAG ?? "";
-if (!tag) throw new Error("missing tag");
-const stripped = tag.replace(/^v/i, "");
-if (!stripped) throw new Error(`unable to derive version from tag "${tag}"`);
-const normalized = stripped.replace(/\.([0-9A-Za-z-]+)\./, "-$1.");
-if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
-  throw new Error(`unsupported release tag "${tag}" -> "${normalized}"`);
-}
-process.stdout.write(normalized);
-' 2>/tmp/npm-release-version.err
-          )" || {
-            cat /tmp/npm-release-version.err >&2
-            exit 1
-          }
+            const tag = process.env.RELEASE_TAG ?? "";
+            if (!tag) throw new Error("missing tag");
+            const stripped = tag.replace(/^v/i, "");
+            if (!stripped) throw new Error(`unable to derive version from tag "${tag}"`);
+            const normalized = stripped.replace(/\.([0-9A-Za-z-]+)\./, "-$1.");
+            if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
+              throw new Error(`unsupported release tag "${tag}" -> "${normalized}"`);
+            }
+            process.stdout.write(normalized);
+            ' 2>/tmp/npm-release-version.err
+                      )" || {
+                        cat /tmp/npm-release-version.err >&2
+                        exit 1
+                      }
           echo "Resolved npm version: ${RELEASE_VERSION}"
           npm version "${RELEASE_VERSION}" --workspace packages/proxmox-openapi --no-git-tag-version
 

--- a/.github/workflows/openapi-release.yml
+++ b/.github/workflows/openapi-release.yml
@@ -61,4 +61,5 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
           fail_on_unmatched_files: true
-          overwrite: true
+          overwrite_files: true
+          


### PR DESCRIPTION
## Summary
- parse release tags from openapi-release and normalize them to valid semver before bumping the npm workspace version
- reuse the same normalization when packaging the GitHub Action so archives receive consistent names even for dot-delimited prerelease tags

## Testing
- npm run typecheck
- npm run build --workspace packages/proxmox-openapi