### PR TITLE
feat: consolidate proxmox-openapi CLI

### DIFF
--- a/.github/actions/proxmox-openapi-artifacts/package.json
+++ b/.github/actions/proxmox-openapi-artifacts/package.json
@@ -10,9 +10,9 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@proxmox-openapi/automation": "0.1.0",
     "@actions/core": "^1.11.1",
-    "@actions/exec": "^1.1.1"
+    "@actions/exec": "^1.1.1",
+    "@mihailfox/proxmox-openapi": "file:../../packages/proxmox-openapi"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/.github/actions/proxmox-openapi-artifacts/src/main.ts
+++ b/.github/actions/proxmox-openapi-artifacts/src/main.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { runAutomationPipeline, type AutomationPipelineRunOptions } from "@proxmox-openapi/automation";
+import { runAutomationPipeline, type AutomationPipelineRunOptions } from "@mihailfox/proxmox-openapi";
 
 function coerceBoolean(input: string | undefined, defaultValue: boolean): boolean {
   if (!input) {

--- a/.github/actions/proxmox-openapi-artifacts/tsup.config.ts
+++ b/.github/actions/proxmox-openapi-artifacts/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   outDir: "dist",
   bundle: true,
   shims: false,
-  noExternal: ["@actions/core", "@actions/exec", "@proxmox-openapi/automation"],
+  noExternal: ["@actions/core", "@actions/exec", "@mihailfox/proxmox-openapi"],
   external: ["playwright", "playwright-core", "chromium-bidi"],
   outExtension() {
     return {

--- a/.github/workflows/automation-pipeline.yml
+++ b/.github/workflows/automation-pipeline.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run automation pipeline (CI mode)
-        run: npm run automation:pipeline -- --report var/automation-summary.json
+      - name: Run proxmox-openapi pipeline (CI mode)
+        run: npx proxmox-openapi pipeline --mode ci --report var/automation-summary.json
 
       - name: Validate generated OpenAPI document
         run: npm run openapi:validate

--- a/app/src/pages/DocsPage.tsx
+++ b/app/src/pages/DocsPage.tsx
@@ -15,9 +15,9 @@ const documents = [
     href: "https://github.com/mihailfox/proxmox-openapi/releases",
   },
   {
-    title: "Automation Pipeline CLI",
-    summary: "Learn how scraping, normalisation, and OpenAPI generation chained together in the CLI pipeline.",
-    href: "https://github.com/mihailfox/proxmox-openapi/tree/main/tools/automation",
+    title: "npm Package & CLI",
+    summary: "Run scrape, normalize, generate, or full automation flows via the consolidated @mihailfox/proxmox-openapi package.",
+    href: "https://github.com/mihailfox/proxmox-openapi/blob/main/docs/packages.md",
   },
 ];
 

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -3,16 +3,16 @@ import { Link } from "react-router-dom";
 
 const featureHighlights = [
   {
-    title: "Fresh OpenAPI bundles",
-    body: "Run the automation pipeline or download the latest GitHub release to stay aligned with the official Proxmox API viewer.",
+    title: "Terraform-ready foundation",
+    body: "OpenAPI bundles power third-party automation, starting with the roadmap to a full Terraform provider for Proxmox VE.",
+  },
+  {
+    title: "Unified CLI & pipeline",
+    body: "The @mihailfox/proxmox-openapi package now handles scraping, normalization, generation, and automation from a single command.",
   },
   {
     title: "Spec explorer",
     body: "Dive into every endpoint using the embedded Swagger UI experience optimised for quick search and filtering.",
-  },
-  {
-    title: "Automation first",
-    body: "GitHub Pages deploys from the main branch with reproducible artifacts and a self-healing project board.",
   },
 ];
 
@@ -26,8 +26,9 @@ export function HomePage() {
         <p className="hero__eyebrow">Proxmox tooling</p>
         <h1 className="hero__title">Unified OpenAPI specs & documentation</h1>
         <p className="hero__subtitle">
-          Generate, explore, and ship Proxmox VE OpenAPI definitions. This SPA bundles the newest schemas, friendly docs,
-          and the automation runbooks that keep everything in sync.
+          Generate, explore, and ship Proxmox VE OpenAPI definitions. Everything here is focused on enabling third-party
+          tooling—starting with the building blocks for a Terraform provider—and the automation runbooks that keep
+          artifacts in sync.
         </p>
         <div className="hero__actions">
           <Link className="button button--primary" to="explorer">

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -10,7 +10,9 @@ This document describes the GitHub automation that keeps the Proxmox OpenAPI del
 - **Beta handling:** Issues attached to milestones containing "beta" are promoted to the Beta stage even if Status is still "In Progress".
 
 ### Pipeline Modes & Flags
-- `npm run automation:pipeline` drives the scrape → normalize → generate flow implemented in `tools/automation/src/pipeline.ts`.
+- `npx proxmox-openapi pipeline` (aliased via `npm run automation:pipeline`) drives the scrape → normalize → generate flow
+  implemented in `tools/automation/src/pipeline.ts`. Stage-specific commands (`proxmox-openapi scrape|normalize|generate`)
+  mirror the dedicated scripts for troubleshooting individual phases.
 - **CI mode (`--mode=ci`)** is the default. It operates offline, reuses cached snapshots, and validates existing artifacts.
 - **Full mode (`--mode=full`)** performs a live scrape using Playwright and honours `--offline`/`--fallback-to-cache` overrides:
   - `--fallback-to-cache` / `--no-fallback-to-cache` control whether cached snapshots are reused when scraping fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "tools/shared"
       ],
       "dependencies": {
+        "@mihailfox/proxmox-openapi": "file:packages/proxmox-openapi",
         "isbot": "^5.1.30",
         "playwright": "^1.55.1",
         "react": "^19.2.0",
@@ -58,7 +59,7 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
-        "@proxmox-openapi/automation": "0.1.0"
+        "@mihailfox/proxmox-openapi": "file:../../packages/proxmox-openapi"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -66,6 +67,11 @@
         "typescript": "^5.9.0"
       }
     },
+    ".github/actions/proxmox-openapi-artifacts/node_modules/@mihailfox/proxmox-openapi": {
+      "resolved": ".github/packages/proxmox-openapi",
+      "link": true
+    },
+    ".github/packages/proxmox-openapi": {},
     "node_modules/@actions/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
@@ -6732,8 +6738,13 @@
       "version": "2.2.5",
       "license": "GPL-3.0",
       "dependencies": {
+        "@proxmox-openapi/api-normalizer": "0.1.0",
+        "@proxmox-openapi/api-scraper": "0.1.0",
         "@proxmox-openapi/automation": "0.1.0",
-        "commander": "^12.1.0"
+        "@proxmox-openapi/openapi-generator": "0.1.0",
+        "@proxmox-openapi/shared": "0.1.0",
+        "commander": "^12.1.0",
+        "yaml": "^2.8.1"
       },
       "bin": {
         "proxmox-openapi": "dist/cli.cjs"

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "format": "biome format --write .",
     "check": "biome check . && npm run action:verify",
     "typecheck": "tsc --build tsconfig.build.json",
-    "scraper:scrape": "tsx tools/api-scraper/src/cli.ts",
-    "normalizer:generate": "tsx tools/api-normalizer/src/cli.ts",
-    "openapi:generate": "tsx tools/openapi-generator/src/cli.ts",
+    "scraper:scrape": "proxmox-openapi scrape",
+    "normalizer:generate": "proxmox-openapi normalize",
+    "openapi:generate": "proxmox-openapi generate",
     "openapi:validate": "tsx tools/openapi-generator/src/validate.ts",
-    "automation:pipeline": "tsx tools/automation/src/cli.ts",
+    "automation:pipeline": "proxmox-openapi pipeline",
     "automation:summary": "tsx tools/automation/scripts/format-summary.ts",
     "openapi:prepare": "node scripts/openapi-sync.mjs",
     "openapi:release:prepare": "node scripts/prepare-openapi-release.mjs",
@@ -79,6 +79,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@mihailfox/proxmox-openapi": "file:packages/proxmox-openapi",
     "isbot": "^5.1.30",
     "playwright": "^1.55.1",
     "react": "^19.2.0",

--- a/packages/proxmox-openapi/package.json
+++ b/packages/proxmox-openapi/package.json
@@ -34,8 +34,13 @@
     "prepublishOnly": "npm run typecheck && npm run build"
   },
   "dependencies": {
+    "@proxmox-openapi/api-normalizer": "0.1.0",
+    "@proxmox-openapi/api-scraper": "0.1.0",
     "@proxmox-openapi/automation": "0.1.0",
-    "commander": "^12.1.0"
+    "@proxmox-openapi/openapi-generator": "0.1.0",
+    "@proxmox-openapi/shared": "0.1.0",
+    "commander": "^12.1.0",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/proxmox-openapi/src/index.ts
+++ b/packages/proxmox-openapi/src/index.ts
@@ -1,8 +1,22 @@
 export {
+  DEFAULT_BASE_URL,
+  scrapeApiDocumentation,
+} from "@proxmox-openapi/api-scraper/scraper.ts";
+export { persistSnapshot } from "@proxmox-openapi/api-scraper/persistence.ts";
+export type { RawApiSnapshot } from "@proxmox-openapi/api-scraper/types.ts";
+export type { ScrapeOptions } from "@proxmox-openapi/api-scraper/scraper.ts";
+
+export { normalizeSnapshot } from "@proxmox-openapi/api-normalizer/normalizer.ts";
+export type { NormalizeSnapshotOptions } from "@proxmox-openapi/api-normalizer/normalizer.ts";
+export type { NormalizedApiDocument } from "@proxmox-openapi/api-normalizer/types.ts";
+
+export { generateOpenApiDocument } from "@proxmox-openapi/openapi-generator/generator.ts";
+export type { GenerateOpenApiOptions } from "@proxmox-openapi/openapi-generator/generator.ts";
+
+export {
   runAutomationPipeline,
   resolveAutomationPipelineOptions,
 } from "@proxmox-openapi/automation";
-
 export type {
   AutomationPipelineResult,
   AutomationPipelineRunOptions,

--- a/packages/proxmox-openapi/src/run-cli.ts
+++ b/packages/proxmox-openapi/src/run-cli.ts
@@ -1,8 +1,22 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import process from "node:process";
-import { Command, Option } from "commander";
 
+import { Command, Option } from "commander";
+import { stringify as stringifyYaml } from "yaml";
+
+import { DEFAULT_BASE_URL, scrapeApiDocumentation } from "@proxmox-openapi/api-scraper/scraper.ts";
+import type { RawApiSnapshot } from "@proxmox-openapi/api-scraper/types.ts";
+import { normalizeSnapshot } from "@proxmox-openapi/api-normalizer/normalizer.ts";
+import type { NormalizedApiDocument } from "@proxmox-openapi/api-normalizer/types.ts";
+import {
+  generateOpenApiDocument,
+  type GenerateOpenApiOptions,
+} from "@proxmox-openapi/openapi-generator/generator.ts";
+import { OPENAPI_ARTIFACT_DIR, OPENAPI_BASENAME } from "@proxmox-openapi/shared/paths.ts";
 import {
   runAutomationPipeline,
+  resolveAutomationPipelineOptions,
   type AutomationPipelineRunOptions,
   type AutomationPipelineResult,
 } from "@proxmox-openapi/automation";
@@ -11,28 +25,41 @@ export interface CliContext {
   readonly command: Command;
 }
 
-function toPipelineOptions(rawOptions: Record<string, unknown>): AutomationPipelineRunOptions {
+const DEFAULT_RAW_SNAPSHOT_PATH = "tools/api-scraper/data/raw/proxmox-openapi-schema.json";
+const DEFAULT_IR_OUTPUT_PATH = "tools/api-normalizer/data/ir/proxmox-openapi-ir.json";
+
+type PipelineCliOptions = AutomationPipelineRunOptions;
+
+function toPipelineOptions(rawOptions: Record<string, unknown>): PipelineCliOptions {
   const mode = typeof rawOptions.mode === "string" && rawOptions.mode === "full" ? "full" : "ci";
 
   return {
     mode,
-    baseUrl: typeof rawOptions.baseUrl === "string" ? rawOptions.baseUrl : undefined,
-    rawSnapshotPath: typeof rawOptions.rawOutput === "string" ? rawOptions.rawOutput : undefined,
-    irOutputPath: typeof rawOptions.irOutput === "string" ? rawOptions.irOutput : undefined,
-    openApiOutputDir: typeof rawOptions.openapiDir === "string" ? rawOptions.openapiDir : undefined,
-    openApiBasename: typeof rawOptions.basename === "string" ? rawOptions.basename : undefined,
-    summaryOutputPath: typeof rawOptions.report === "string" ? rawOptions.report : undefined,
-    fallbackToCache: typeof rawOptions.fallbackToCache === "boolean" ? rawOptions.fallbackToCache : undefined,
-    offline: typeof rawOptions.offline === "boolean" ? rawOptions.offline : undefined,
-  } satisfies AutomationPipelineRunOptions;
+    baseUrl: asString(rawOptions.baseUrl),
+    rawSnapshotPath: asString(rawOptions.rawOutput),
+    irOutputPath: asString(rawOptions.irOutput),
+    openApiOutputDir: asString(rawOptions.openapiDir),
+    openApiBasename: asString(rawOptions.basename),
+    summaryOutputPath: asString(rawOptions.report),
+    fallbackToCache: asBoolean(rawOptions.fallbackToCache),
+    offline: asBoolean(rawOptions.offline),
+  };
 }
 
-function buildCommand(): Command {
-  const program = new Command();
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
 
-  program
-    .name("proxmox-openapi")
-    .description("Generate Proxmox OpenAPI artifacts for Proxmox VE.")
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+function configurePipelineCommand(command: Command): Command {
+  return command
+    .description("Run the scrape → normalize → generate automation pipeline.")
     .option("-m, --mode <mode>", "Pipeline mode (ci|full)", "ci")
     .option("--base-url <url>", "Override the Proxmox API viewer base URL")
     .option("--raw-output <path>", "Path for the raw snapshot JSON output")
@@ -45,16 +72,164 @@ function buildCommand(): Command {
     .option("--offline", "Force offline mode (skip live scraping)")
     .action(async (opts: Record<string, unknown>) => {
       const pipelineOptions = toPipelineOptions(opts);
+      const resolved = resolveAutomationPipelineOptions(pipelineOptions);
       const result: AutomationPipelineResult = await runAutomationPipeline(pipelineOptions);
 
-      if (pipelineOptions.summaryOutputPath) {
-        console.log(`Summary written to ${pipelineOptions.summaryOutputPath}`);
+      if (resolved.summaryOutputPath) {
+        console.log(`Summary written to ${relative(resolved.summaryOutputPath)}`);
       }
 
-      const payloadDir = pipelineOptions.openApiOutputDir ?? "var/openapi";
-      console.log(`OpenAPI artifacts available in ${payloadDir}`);
+      console.log(`OpenAPI artifacts available in ${relative(resolved.openApiOutputDir)}`);
       console.log(`Cache usage: ${result.usedCache ? "reused cached snapshot" : "fresh scrape"}`);
     });
+}
+
+function configureScrapeCommand(command: Command): Command {
+  return command
+    .description("Scrape the Proxmox API viewer and emit the raw snapshot JSON.")
+    .option("--base-url <url>", "Override the Proxmox API viewer base URL")
+    .option("--output <path>", "Path for the raw snapshot JSON output", DEFAULT_RAW_SNAPSHOT_PATH)
+    .option("--no-persist", "Disable writing the snapshot to disk (prints stats only)")
+    .action(async (opts: Record<string, unknown>) => {
+      const baseUrl = asString(opts.baseUrl);
+      const outputPath = asString(opts.output) ?? DEFAULT_RAW_SNAPSHOT_PATH;
+      const shouldPersist = opts.persist !== false;
+      const resolvedOutput = path.resolve(outputPath);
+
+      const persist = shouldPersist
+        ? {
+            outputDir: path.dirname(resolvedOutput),
+            fileName: path.basename(resolvedOutput),
+          }
+        : false;
+
+      const { snapshot, filePath } = await scrapeApiDocumentation({
+        baseUrl,
+        persist,
+      });
+
+      console.log(
+        [
+          `Scraped ${snapshot.stats.rootGroupCount} groups`,
+          `${snapshot.stats.endpointCount} endpoints`,
+          `source: ${baseUrl ?? DEFAULT_BASE_URL}`,
+        ].join(" | ")
+      );
+
+      if (filePath) {
+        console.log(`Snapshot saved to ${relative(filePath)}`);
+      }
+    });
+}
+
+function configureNormalizeCommand(command: Command): Command {
+  return command
+    .description("Normalize a scraped snapshot into the intermediate representation (IR).")
+    .option("--input <path>", "Path to the raw snapshot JSON", DEFAULT_RAW_SNAPSHOT_PATH)
+    .option("--output <path>", "Where to write the normalized IR JSON", DEFAULT_IR_OUTPUT_PATH)
+    .action(async (opts: Record<string, unknown>) => {
+      const inputPath = path.resolve(asString(opts.input) ?? DEFAULT_RAW_SNAPSHOT_PATH);
+      const outputPath = path.resolve(asString(opts.output) ?? DEFAULT_IR_OUTPUT_PATH);
+
+      const payload = await fs.readFile(inputPath, "utf8");
+      const snapshot = JSON.parse(payload) as RawApiSnapshot;
+      const normalized = normalizeSnapshot(snapshot);
+
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+
+      console.log(`Normalized IR written to ${relative(outputPath)}`);
+    });
+}
+
+function configureGenerateCommand(command: Command): Command {
+  return command
+    .description("Generate OpenAPI documents from the normalized IR.")
+    .option("--input <path>", "Path to the normalized IR JSON", DEFAULT_IR_OUTPUT_PATH)
+    .option("--output <dir>", "Directory for generated OpenAPI files", OPENAPI_ARTIFACT_DIR)
+    .option("-b, --basename <name>", "Basename for the OpenAPI files", OPENAPI_BASENAME)
+    .option("--format <formats>", "Comma-separated list of formats (json,yaml)", "json,yaml")
+    .option("--server-url <url>", "Override the server URL baked into the OpenAPI document")
+    .action(async (opts: Record<string, unknown>) => {
+      const inputPath = path.resolve(asString(opts.input) ?? DEFAULT_IR_OUTPUT_PATH);
+      const outputDir = path.resolve(asString(opts.output) ?? OPENAPI_ARTIFACT_DIR);
+      const basename = asString(opts.basename) ?? OPENAPI_BASENAME;
+      const serverUrl = asString(opts.serverUrl);
+      const formats = parseFormats(opts.format);
+
+      const payload = await fs.readFile(inputPath, "utf8");
+      const normalized = JSON.parse(payload) as NormalizedApiDocument;
+
+      const options: GenerateOpenApiOptions = {};
+      if (serverUrl) {
+        options.serverUrl = serverUrl;
+      }
+
+      const document = generateOpenApiDocument(normalized, options);
+
+      await fs.mkdir(outputDir, { recursive: true });
+
+      const written: string[] = [];
+
+      if (formats.has("json")) {
+        const jsonPath = path.join(outputDir, `${basename}.json`);
+        await fs.writeFile(jsonPath, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+        written.push(jsonPath);
+      }
+
+      if (formats.has("yaml")) {
+        const yamlPath = path.join(outputDir, `${basename}.yaml`);
+        await fs.writeFile(yamlPath, `${stringifyYaml(document)}\n`, "utf8");
+        written.push(yamlPath);
+      }
+
+      if (written.length === 0) {
+        throw new Error("No output formats selected. Use --format to include json and/or yaml.");
+      }
+
+      for (const filePath of written) {
+        console.log(`Generated ${relative(filePath)}`);
+      }
+    });
+}
+
+function parseFormats(value: unknown): Set<"json" | "yaml"> {
+  if (!value) {
+    return new Set(["json", "yaml"]);
+  }
+
+  const tokens = String(value)
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+
+  const formats = new Set<"json" | "yaml">();
+
+  for (const token of tokens) {
+    if (token === "json" || token === "yaml") {
+      formats.add(token);
+    }
+  }
+
+  return formats;
+}
+
+function relative(filePath: string): string {
+  return path.relative(process.cwd(), filePath);
+}
+
+function buildCommand(): Command {
+  const program = new Command()
+    .name("proxmox-openapi")
+    .description("Scrape, normalize, and generate Proxmox VE OpenAPI artifacts.");
+
+  configurePipelineCommand(program);
+  configurePipelineCommand(program.command("pipeline").alias("run"));
+  configureScrapeCommand(program.command("scrape"));
+  configureNormalizeCommand(program.command("normalize"));
+  configureGenerateCommand(program.command("generate"));
+
+  program.showHelpAfterError();
 
   return program;
 }

--- a/packages/proxmox-openapi/tsup.config.ts
+++ b/packages/proxmox-openapi/tsup.config.ts
@@ -10,6 +10,8 @@ export default defineConfig([
     outDir: "dist",
     target: "node18",
     tsconfig: "tsconfig.tsup.json",
+    noExternal: [/^@proxmox-openapi\//],
+    external: ["playwright", "playwright-core", "chromium-bidi"],
   },
   {
     entry: { cli: "src/cli.ts" },
@@ -19,6 +21,8 @@ export default defineConfig([
     outDir: "dist",
     target: "node18",
     tsconfig: "tsconfig.tsup.json",
+    noExternal: [/^@proxmox-openapi\//],
+    external: ["playwright", "playwright-core", "chromium-bidi"],
     banner: {
       js: "#!/usr/bin/env node",
     },


### PR DESCRIPTION
## Summary
- wrap the scraper, normalizer, generator, and automation stages inside `@mihailfox/proxmox-openapi`
- add CLI subcommands for `pipeline`, `scrape`, `normalize`, and `generate` plus bundle internal workspace code
- update the reusable action, automation workflow, docs, and site copy to highlight the Terraform-centric roadmap

Fixes #51

## Testing
- npm run lint
- npm run typecheck
- npm run build --workspace packages/proxmox-openapi