### PR TITLE
fix: build cli before openapi artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build CLI workspace
+        run: npm run build --workspace packages/proxmox-openapi
+
       - name: Generate OpenAPI artifacts
         run: npm run automation:pipeline -- --mode=full --report var/automation-summary.json
 


### PR DESCRIPTION
## Summary
- run the CLI build in the release openapi job so the proxmox-openapi binary is available before running the automation pipeline

## Testing
- npm run build --workspace packages/proxmox-openapi