### PR TITLE
chore(ci): simplify pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,14 +34,16 @@ jobs:
           cache-dependency-path: package-lock.json
       # Install workspace dependencies (automation + SPA).
       - name: Install dependencies
-        run: npm install
-      - name: Build automation package
-        run: npm run build --workspace packages/proxmox-openapi
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npm install --workspaces --include-workspace-root
       # Generate the raw snapshot, normalized IR, and OpenAPI bundles consumed by the SPA.
       - name: Generate OpenAPI artifacts
-        run: node packages/proxmox-openapi/dist/cli.cjs pipeline --mode=ci --report var/automation-summary.json
+        uses: mihailfox/proxmox-openapi/.github/actions/proxmox-openapi-artifacts@v1
+        with:
+          mode: ci
+          install-command: ""
+          report-path: var/automation-summary.json
+          openapi-dir: var/openapi
+          fallback-to-cache: true
       # Build the static site and copy artifacts into the Vite output for GitHub Pages.
       - name: Build static site
         env:


### PR DESCRIPTION
## Summary
- replace the bespoke automation pipeline steps in deploy-pages with the published Proxmox OpenAPI artifacts action
- drop the local CLI build and Playwright install in favour of the bundled action logic
- keep the automation summary and OpenAPI outputs flowing into `var/` for the Pages bundler

## Testing
- not run (workflow-only change)