### PR TITLE
docs: refresh guidance and include changelog in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ Notes for maintainers:
 ## Unreleased
 
 ### Changed
-- CI/Pages: simplify GitHub Pages workflow to reduce steps.
+- CI/Pages: install the latest published CLI from GitHub Packages before automation runs.
+- Release workflow: push version bumps back to `main` after publishing.
 
 ### Fixed
 - CI/Actions: reference the local bundled action to avoid resolution issues (#74).
 - CI/Release: use generated action in release workflow for consistent behaviour (#73).
+- GitHub Action: build the local CLI workspace when the published package is unavailable.
 
 ## v0.2.9 — 2025-11-02
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ jobs:
           fallback-to-cache: true
 ```
 
+> **Note**
+> Workflows that install `@mihailfox/proxmox-openapi` must configure npm for GitHub Packages. For example:
+> 
+> ```bash
+> cat <<'RC' >> ~/.npmrc
+> //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+> @mihailfox:registry=https://npm.pkg.github.com
+> RC
+> ```
+
 ### Self-hosted runners (offline-compatible)
 
 Download the release bundle and reference it locally:

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -45,6 +45,7 @@ Use this checklist when tagging a new release:
    - Run `npm run automation:pipeline -- --mode=full --report var/automation-summary.json` locally or in CI.
    - Confirm `npm run openapi:validate` succeeds.
    - Stage schema bundles with `npm run openapi:release:prepare -- <tag>` if you need to preview release notes.
+   - Verify `.npmrc` is configured for GitHub Packages (`@mihailfox:registry=https://npm.pkg.github.com`) so the release workflow can publish and consume the CLI.
 
 2. **Tag and push**
    - Create an annotated tag (for example `git tag -a v1.2.0 -m "Proxmox OpenAPI v1.2.0"`).

--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -6,7 +6,8 @@ Follow these steps when publishing `@mihailfox/proxmox-openapi` to GitHub Packag
    - Run `npm run automation:pipeline -- --mode=full --report var/automation-summary.json`.
    - Ensure `npm run openapi:validate` passes.
    - Update the changelog and documentation for the upcoming version.
-   - Ensure the top “Unreleased” section in `CHANGELOG.md` accurately summarizes user‑visible changes (it becomes the release body).
+   - Ensure the top “Unreleased” section in `CHANGELOG.md` accurately summarizes user-visible changes (it becomes the release body).
+   - Confirm your `.npmrc` routes `@mihailfox` to `https://npm.pkg.github.com` so the release workflow can authenticate.
 
 2. **Versioning & tagging**
    - Tag the release (`git tag -a vX.Y.Z -m "Proxmox OpenAPI vX.Y.Z"`). The GitHub release workflow aligns every package.json (root, CLI, GitHub Action) to `X.Y.Z` using `scripts/set-release-version.mjs`.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -82,3 +82,4 @@ into the internal workspace packages.
 
 ## Notes
 > When installing in CI, set `NODE_AUTH_TOKEN` or include the token in `.npmrc`. Use a token with `read:packages` scope.
+> Use `npm install --no-save @mihailfox/proxmox-openapi@latest --registry=https://npm.pkg.github.com` when you always want the newest published CLI.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -79,6 +79,7 @@ npm install --registry=https://npm.pkg.github.com/@mihailfox/proxmox-openapi
 - The release workflow aligns the root workspace, npm package, and GitHub Action versions with the tag (e.g., `v1.2.3` → `1.2.3`).
 - Each release records the upstream Proxmox VE version via `scripts/fetch_pve_docs_metadata.py` so consumers can map schema changes to PVE builds.
 - After all artifacts publish successfully, the workflow commits the version bump back to `main`, keeping package.json metadata in sync with the latest tag.
+- Any workflow that installs `@mihailfox/proxmox-openapi` (e.g., GitHub Pages) must configure `.npmrc` for GitHub Packages or the install will fall back to the public npm registry and fail.
 
 ## Notes
 > The JSON OpenAPI document is the canonical artifact for automation. The YAML variant mirrors the JSON content and exists for convenience.


### PR DESCRIPTION
## Summary
- update documentation and changelog with current workflow behaviour (GitHub Packages auth, auto version sync)
- enhance release script to append the matching CHANGELOG section to generated release notes

## Testing
- npm run format