### PR TITLE
fix(release): stabilize changelog-driven release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project are documented here. The format follows
 Common Changelog with the sections: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 Notes for maintainers:
-- Keep the Unreleased section up-to-date. Our release workflow uses its
-  content as the body of the GitHub release notes for the next tag.
+- Keep the Unreleased section up-to-date. Our release workflow copies it into
+  the release notes whenever a tagged heading is missing, so remember to move
+  entries into the new version section right after publishing.
 - Dates use ISO format (YYYY-MM-DD). The project requires Node.js 24+.
 
 ## Unreleased

--- a/docs/architecture-low-level.md
+++ b/docs/architecture-low-level.md
@@ -176,7 +176,10 @@ Node-friendly shebang handling in the bundled `dist/cli.cjs`.
 - `scripts/prepare-openapi-release.mjs` reads cached IR and snapshot files,
   computes SHA-256 digests, inspects `CHANGELOG.md`, and writes both a staged
   directory (`var/openapi-release/proxmox-openapi-schema-<tag>`) and release
-  notes. It shells out to `git tag` to resolve previous versions.
+  notes. It shells out to `git tag` to resolve previous versions, fetches the
+  prior release notes when cached artifacts are unavailable, embeds an
+  `openapi-stats` marker for machine-readable baselines, and falls back to the
+  `## Unreleased` changelog section whenever the tagged entry is still pending.
 - `scripts/prepare-pages.mjs` verifies a Vite build exists, copies the OpenAPI
   bundle into `dist/openapi`, adds a `404.html` fallback, and mirrors the result
   into `var/pages/` for GitHub Pages deployment.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,11 @@ flowchart TD
   - `openapi-sync.mjs` copies generated artifacts into the SPA assets before dev
     or build steps.
   - `prepare-openapi-release.mjs` assembles release bundles, computes checksums,
-    compares against previous tags, and emits markdown notes.
+    compares against previous tags (even when cache files are absent by
+    reading the prior release notes), and emits markdown notes with an embedded
+    `openapi-stats` marker for future diffs. When the tagged changelog entry is
+    missing it falls back to `## Unreleased`, preserving the expected release
+    cadence.
   - `prepare-pages.mjs` stages the SPA build plus OpenAPI bundle in `var/pages/`
     with a `404.html` fallback for GitHub Pages.
 

--- a/scripts/prepare-openapi-release.mjs
+++ b/scripts/prepare-openapi-release.mjs
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const [requestedTag] = process.argv.slice(2);
 const tagName = requestedTag ?? process.env.GITHUB_REF_NAME ?? "dev";
@@ -10,6 +11,7 @@ const workspace = process.cwd();
 const artifactsDir = path.resolve("var", "openapi");
 const releaseRoot = path.resolve("var", "openapi-release");
 const stagingDir = path.join(releaseRoot, `proxmox-openapi-schema-${tagName}`);
+const RELEASE_STATS_MARKER = "openapi-stats";
 async function main() {
   await fs.rm(stagingDir, { recursive: true, force: true });
   await fs.mkdir(stagingDir, { recursive: true });
@@ -65,7 +67,8 @@ async function buildChecksumManifest(assetPaths) {
 async function composeReleaseNotes(tag, proxmoxVersion, changelogSection) {
   const current = await readWorkingState();
   const previousTag = resolvePreviousTag(tag);
-  const previous = previousTag ? await readStateAtRef(previousTag) : null;
+  const previous = previousTag ? await loadPreviousStats(previousTag) : null;
+  const currentStats = buildStatsPayload(tag, current);
 
   const lines = [];
   lines.push(`# Proxmox OpenAPI schema ${tag}`);
@@ -78,17 +81,40 @@ async function composeReleaseNotes(tag, proxmoxVersion, changelogSection) {
   }
   lines.push("");
 
-  if (previous) {
+  if (previous && hasSummary(previous) && hasSummary(currentStats) && previousTag) {
     lines.push(`## Changes since ${previousTag}`);
     lines.push("");
-    lines.push(formatDelta("Groups", previous.normalized.summary.groupCount, current.normalized.summary.groupCount));
     lines.push(
-      formatDelta("Endpoints", previous.normalized.summary.endpointCount, current.normalized.summary.endpointCount)
+      formatDelta("Groups", previous.normalized.summary.groupCount, currentStats.normalized.summary.groupCount)
     );
-    lines.push(formatDelta("Methods", previous.normalized.summary.methodCount, current.normalized.summary.methodCount));
     lines.push(
-      formatDelta("Raw snapshot endpoints", previous.snapshot.stats.endpointCount, current.snapshot.stats.endpointCount)
+      formatDelta("Endpoints", previous.normalized.summary.endpointCount, currentStats.normalized.summary.endpointCount)
     );
+    lines.push(
+      formatDelta("Methods", previous.normalized.summary.methodCount, currentStats.normalized.summary.methodCount)
+    );
+    if (previous.snapshot.stats?.endpointCount != null && currentStats.snapshot.stats?.endpointCount != null) {
+      lines.push(
+        formatDelta(
+          "Raw snapshot endpoints",
+          previous.snapshot.stats.endpointCount,
+          currentStats.snapshot.stats.endpointCount
+        )
+      );
+    }
+  } else if (previousTag) {
+    lines.push(`## Changes since ${previousTag}`);
+    lines.push("");
+    lines.push("Previous release notes did not include OpenAPI stats; reporting current snapshot for reference.");
+    lines.push("");
+    if (currentStats.normalized.summary) {
+      lines.push(`- Groups: ${currentStats.normalized.summary.groupCount}`);
+      lines.push(`- Endpoints: ${currentStats.normalized.summary.endpointCount}`);
+      lines.push(`- Methods: ${currentStats.normalized.summary.methodCount}`);
+    }
+    if (currentStats.snapshot.stats?.endpointCount != null) {
+      lines.push(`- Raw snapshot endpoints: ${currentStats.snapshot.stats.endpointCount}`);
+    }
   } else {
     lines.push("## Changes");
     lines.push("");
@@ -102,14 +128,173 @@ async function composeReleaseNotes(tag, proxmoxVersion, changelogSection) {
   lines.push("- OpenAPI YAML: `proxmox-ve.yaml`");
   lines.push("- Checksums: `openapi.sha256.json`");
 
-  if (changelogSection && changelogSection.trim() !== "") {
+  const content = changelogSection?.content?.trim();
+  if (content) {
     lines.push("");
     lines.push("## Changelog");
+    if (changelogSection.source && changelogSection.source.toLowerCase() === "unreleased") {
+      lines.push("");
+      lines.push("_Derived from the Unreleased section at release time._");
+    }
     lines.push("");
-    lines.push(changelogSection.trim());
+    lines.push(content);
   }
 
+  lines.push("");
+  lines.push(renderStatsMarker(currentStats));
+
   return lines.join("\n");
+}
+
+async function loadPreviousStats(tag) {
+  const cachedState = await readStateAtRef(tag);
+  if (cachedState) {
+    return buildStatsPayload(tag, cachedState);
+  }
+  return loadStatsFromReleaseNotes(tag);
+}
+
+function buildStatsPayload(tag, state) {
+  const normalized = state?.normalized ?? {};
+  const snapshot = state?.snapshot ?? {};
+  return {
+    tag,
+    normalized: {
+      normalizedAt: normalized.normalizedAt ?? null,
+      summary: copySummary(normalized.summary),
+    },
+    snapshot: {
+      scrapedAt: snapshot.scrapedAt ?? null,
+      stats: copyRawStats(snapshot.stats),
+    },
+  };
+}
+
+function hasSummary(stats) {
+  return Boolean(
+    stats?.normalized?.summary &&
+      typeof stats.normalized.summary.groupCount === "number" &&
+      typeof stats.normalized.summary.endpointCount === "number" &&
+      typeof stats.normalized.summary.methodCount === "number"
+  );
+}
+
+function renderStatsMarker(stats) {
+  return `<!-- ${RELEASE_STATS_MARKER}: ${JSON.stringify(stats)} -->`;
+}
+
+function copySummary(summary) {
+  if (!summary) {
+    return null;
+  }
+  const { groupCount, endpointCount, methodCount } = summary;
+  if (typeof groupCount !== "number" || typeof endpointCount !== "number" || typeof methodCount !== "number") {
+    return null;
+  }
+  return { groupCount, endpointCount, methodCount };
+}
+
+function copyRawStats(stats) {
+  if (!stats) {
+    return null;
+  }
+  const { endpointCount, rootGroupCount } = stats;
+  const payload = {};
+  if (typeof endpointCount === "number") {
+    payload.endpointCount = endpointCount;
+  }
+  if (typeof rootGroupCount === "number") {
+    payload.rootGroupCount = rootGroupCount;
+  }
+  return Object.keys(payload).length > 0 ? payload : null;
+}
+
+async function loadStatsFromReleaseNotes(tag) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    return null;
+  }
+
+  const token = selectGitHubToken();
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "proxmox-openapi-release-script",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const url = `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`;
+  try {
+    const response = await fetch(url, { headers });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      console.warn(
+        `[openapi-release] Unable to read release notes for ${tag}: ${response.status} ${response.statusText}`
+      );
+      return null;
+    }
+    const payload = await response.json();
+    const marker = parseStatsMarker(payload.body ?? "");
+    if (!marker) {
+      return null;
+    }
+    return normalizeStatsPayload(marker, tag);
+  } catch (error) {
+    console.warn(
+      `[openapi-release] Failed to fetch release notes for ${tag}: ${error instanceof Error ? error.message : error}`
+    );
+    return null;
+  }
+}
+
+function parseStatsMarker(body) {
+  if (!body) {
+    return null;
+  }
+  const markerRegex = new RegExp(`<!--\\s*${RELEASE_STATS_MARKER}:\\s*({[\\s\\S]*?})\\s*-->`);
+  const match = markerRegex.exec(body);
+  if (!match) {
+    return null;
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch (error) {
+    console.warn(
+      `[openapi-release] Unable to parse ${RELEASE_STATS_MARKER} marker: ${error instanceof Error ? error.message : error}`
+    );
+    return null;
+  }
+}
+
+function normalizeStatsPayload(payload, fallbackTag) {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const normalized = payload.normalized ?? {};
+  const snapshot = payload.snapshot ?? {};
+  const summary = copySummary(normalized.summary);
+  const stats = copyRawStats(snapshot.stats);
+  if (!summary && !stats) {
+    return null;
+  }
+  return {
+    tag: typeof payload.tag === "string" ? payload.tag : fallbackTag,
+    normalized: {
+      normalizedAt: typeof normalized.normalizedAt === "string" ? normalized.normalizedAt : null,
+      summary,
+    },
+    snapshot: {
+      scrapedAt: typeof snapshot.scrapedAt === "string" ? snapshot.scrapedAt : null,
+      stats,
+    },
+  };
+}
+
+function selectGitHubToken() {
+  return process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? process.env.GH_PAT ?? process.env.GITHUB_PAT ?? null;
 }
 
 function formatDelta(label, previous, current) {
@@ -183,40 +368,58 @@ async function writeJson(filePath, payload) {
 async function extractChangelogSection(tag) {
   try {
     const changelog = await fs.readFile(path.resolve("CHANGELOG.md"), "utf8");
-    const headingRegex = new RegExp(`^##\\s+${escapeRegExp(tag)}(?:\\s+—.*)?$`, "m");
-    const lines = changelog.split("\n");
-    let start = -1;
-    for (let i = 0; i < lines.length; i += 1) {
-      if (headingRegex.test(lines[i])) {
-        start = i + 1;
-        break;
-      }
+    const tagged = findChangelogSection(changelog, tag);
+    if (tagged) {
+      return { content: tagged, source: tag };
     }
-    if (start === -1) {
-      return "";
+    const fallback = findChangelogSection(changelog, "Unreleased");
+    if (fallback) {
+      return { content: fallback, source: "Unreleased" };
     }
-    let end = lines.length;
-    for (let i = start; i < lines.length; i += 1) {
-      if (lines[i].startsWith("## ")) {
-        end = i;
-        break;
-      }
-    }
-    const sectionLines = lines.slice(start, end);
-    while (sectionLines.length && sectionLines[0].trim() === "") sectionLines.shift();
-    while (sectionLines.length && sectionLines[sectionLines.length - 1].trim() === "") sectionLines.pop();
-    return sectionLines.join("\n");
+    return { content: "", source: null };
   } catch (error) {
     console.warn(`[openapi-release] Unable to read CHANGELOG: ${error instanceof Error ? error.message : error}`);
-    return "";
+    return { content: "", source: null };
   }
+}
+
+function findChangelogSection(changelog, heading) {
+  const headingRegex = new RegExp(`^##\\s+${escapeRegExp(heading)}(?:\\s+—.*)?$`, "m");
+  const lines = changelog.split("\n");
+  let start = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (headingRegex.test(lines[i])) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) {
+    return null;
+  }
+  let end = lines.length;
+  for (let i = start; i < lines.length; i += 1) {
+    if (lines[i].startsWith("## ")) {
+      end = i;
+      break;
+    }
+  }
+  const sectionLines = lines.slice(start, end);
+  while (sectionLines.length && sectionLines[0].trim() === "") sectionLines.shift();
+  while (sectionLines.length && sectionLines[sectionLines.length - 1].trim() === "") sectionLines.pop();
+  return sectionLines.join("\n");
 }
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-main().catch((error) => {
-  console.error(`[openapi-release] ${error instanceof Error ? (error.stack ?? error.message) : error}`);
-  process.exitCode = 1;
-});
+const isDirectExecution = Boolean(process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url));
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(`[openapi-release] ${error instanceof Error ? (error.stack ?? error.message) : error}`);
+    process.exitCode = 1;
+  });
+}
+
+export { composeReleaseNotes, extractChangelogSection };

--- a/tests/release/prepare-openapi-release.test.mjs
+++ b/tests/release/prepare-openapi-release.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { mock, test } from "node:test";
+
+import { extractChangelogSection } from "../../scripts/prepare-openapi-release.mjs";
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+## Unreleased
+
+### Added
+- Unreleased feature
+
+### Fixed
+- Another fix still pending
+
+## v1.2.3 — 2025-11-04
+
+### Changed
+- Updated workflow logic
+
+### Fixed
+- Patched automation pipeline
+`;
+
+test("extractChangelogSection returns matching tagged section", async (t) => {
+  const readFileMock = mock.method(fs, "readFile", async () => SAMPLE_CHANGELOG);
+  t.after(() => readFileMock.mock.restore());
+
+  const result = await extractChangelogSection("v1.2.3");
+  assert.equal(result.source, "v1.2.3");
+  assert.ok(result.content.includes("### Changed"));
+  assert.ok(result.content.includes("Patched automation pipeline"));
+});
+
+test("extractChangelogSection falls back to Unreleased section", async (t) => {
+  const readFileMock = mock.method(fs, "readFile", async () => SAMPLE_CHANGELOG);
+  t.after(() => readFileMock.mock.restore());
+
+  const result = await extractChangelogSection("v1.3.0");
+  assert.equal(result.source, "Unreleased");
+  assert.ok(result.content.includes("Unreleased feature"));
+  assert.ok(result.content.includes("Another fix still pending"));
+});
+
+test("extractChangelogSection returns empty payload when changelog missing", async (t) => {
+  const error = new Error("missing file");
+  const readFileMock = mock.method(fs, "readFile", async () => {
+    throw error;
+  });
+  t.after(() => readFileMock.mock.restore());
+
+  const result = await extractChangelogSection("v1.3.0");
+  assert.equal(result.source, null);
+  assert.equal(result.content, "");
+});


### PR DESCRIPTION
## Summary
- fallback to the Unreleased section when a tag heading is absent
- embed openapi-stats markers and reuse previous release notes for baseline counts
- add node-based tests and refresh docs

## Testing
- node --test tests/release/prepare-openapi-release.test.mjs