### PR TITLE
ci: enforce concurrency and refresh docs

### DIFF
--- a/.github/workflows/automation-pipeline.yml
+++ b/.github/workflows/automation-pipeline.yml
@@ -46,6 +46,10 @@ on:
         default: "false"
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -6,6 +6,10 @@ on:
       - "**/*.md"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -23,4 +27,3 @@ jobs:
           node-version: 24
       - name: Run link checker
         run: node scripts/check-doc-links.mjs
-

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: 'pages'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/project-stage-sync.yml
+++ b/.github/workflows/project-stage-sync.yml
@@ -9,6 +9,10 @@ on:
   project_card:
     types: [created, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,20 @@ Notes for maintainers:
 ## Unreleased
 
 ### Changed
+- CI: enforce GitHub concurrency groups across every workflow so superseded runs cancel automatically.
 - CI/Pages: install the latest published CLI from GitHub Packages before automation runs.
 - Release workflow: push version bumps back to `main` after publishing.
+- Release tooling: append the artifact inventory after changelog-driven release notes for consistent release bodies (#101).
+- Devcontainer: persist shell history via `${HOME}/.dev_con_bash_history` to isolate workspaces (#101).
 
 ### Fixed
+- Release tooling: stabilize changelog-driven release notes fallback logic (#100).
 - CI/Actions: reference the local bundled action to avoid resolution issues (#74).
 - CI/Release: use generated action in release workflow for consistent behaviour (#73).
 - GitHub Action: build the local CLI workspace when the published package is unavailable.
+
+### Removed
+- Devcontainer: drop the claude-code installer from post-create provisioning (#101).
 
 ## v0.2.9 — 2025-11-02
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ for targeted debugging.
 ### Devcontainer & launcher helpers
 - The devcontainer definition lives under `.devcontainer/`; see [docs/devcontainer.md](docs/devcontainer.md) for the full
   image layout, helper scripts, and troubleshooting tips.
+- Shell history persists through the `${HOME}/.dev_con_bash_history` bind mount so multiple Devcontainer workspaces can
+  coexist without clobbering `~/.bash_history` on the host.
 - `./launcher.sh` wraps the most common devcontainer actions:
   - `./launcher.sh vscode --attach-shell` opens the repo in VS Code and waits for the container before spawning a shell.
   - `./launcher.sh get_config customizations.vscode.settings` queries arbitrary paths from `devcontainer.json` if you
@@ -98,6 +100,7 @@ for targeted debugging.
 The "Project Stage Sync" workflow keeps the delivery project up to date. Review the [automation runbook](docs/automation.md) for triggers,
 token requirements, CLI flags, and manual override instructions. When opening a pull request, ensure the relevant issue is linked so the
 workflow can reconcile status changes. Use `packages/proxmox-openapi/scripts/automation/format-summary.ts` to turn pipeline summaries into Markdown for PRs.
+CI workflows run under concurrency groups (`${{ github.workflow }}-${{ github.ref }}`) so any superseded run is cancelled before new work starts.
 
 ## Monitoring & Quality
 - Run a Lighthouse audit (Performance, Accessibility, Best Practices ≥ 90) against the deployed pages site after significant UI changes.

--- a/docs/architecture-low-level.md
+++ b/docs/architecture-low-level.md
@@ -25,6 +25,9 @@ flowchart TD
         D2[cli.ts]
         D3[cli-arg-utils.ts]
     end
+    subgraph Release[release tooling]
+        F1[prepare-openapi-release.mjs]
+    end
     subgraph Shared[shared]
         E1[paths.ts]
         E2[module-paths.ts]
@@ -32,10 +35,14 @@ flowchart TD
     Scraper --> Normalizer
     Normalizer --> Generator
     Generator --> Automation
+    Automation --> Release
+    Normalizer --> Release
+    Generator --> Release
     Shared --> Scraper
     Shared --> Normalizer
     Shared --> Generator
     Shared --> Automation
+    Shared --> Release
 ```
 
 ### `api-scraper`
@@ -180,6 +187,9 @@ Node-friendly shebang handling in the bundled `dist/cli.cjs`.
   prior release notes when cached artifacts are unavailable, embeds an
   `openapi-stats` marker for machine-readable baselines, and falls back to the
   `## Unreleased` changelog section whenever the tagged entry is still pending.
+  The composer now always appends the artifact inventory after the changelog
+  excerpt so first-time releases and maintenance updates alike include the
+  canonical download hints without duplicating placeholder sections.
 - `scripts/prepare-pages.mjs` verifies a Vite build exists, copies the OpenAPI
   bundle into `dist/openapi`, adds a `404.html` fallback, and mirrors the result
   into `var/pages/` for GitHub Pages deployment.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -11,6 +11,8 @@ Keep the delivery project fields in sync and define how the automation pipeline 
 - **Triggers:** Hourly cron, manual `workflow_dispatch`, issue activity, and `project_card` events (created/edited).
 - **Token usage:** The job requests `repository-projects: write`. It prefers the `PROJECT_AUTOMATION_TOKEN` secret for broader scopes and automatically falls back to the default `GITHUB_TOKEN` when the PAT is absent.
 - **Beta handling:** Issues attached to milestones containing "beta" are promoted to the Beta stage even if Status is still "In Progress".
+- **Concurrency:** The workflow runs under GitHub's `${{ github.workflow }}-${{ github.ref }}` group, cancelling older in-flight
+  runs whenever a new sync starts so the project board never flaps between duplicate updates.
 
 ### Pipeline Modes & Flags
 - `npx proxmox-openapi pipeline` (aliased via `npm run automation:pipeline`) drives the scrape → normalize → generate flow
@@ -52,6 +54,7 @@ Use this checklist when tagging a new release:
 
 3. **Automated workflows**
    - Publishing a GitHub Release triggers `.github/workflows/release.yml`, which aligns all package versions with the tag, scrapes the upstream Proxmox VE version, regenerates artifacts, writes release notes, publishes assets via `softprops/action-gh-release@v2`, and commits the version bump back to `main`. It also builds and publishes `@mihailfox/proxmox-openapi` to GitHub Packages with provenance.
+   - The release notes composer always appends the artifact inventory after the changelog content, even for first-time releases with no prior history.
 
 4. **Post-publish validation**
    - Download archives from the GitHub release and verify checksums (`openapi.sha256.json`).

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -49,7 +49,9 @@ Before the container starts, `.devcontainer/scripts/initialize-host.sh` runs on 
 The script reuses `command_get_config` from `scripts/common.sh`
 to enumerate the `mounts` array in `devcontainer.json`, resolve `${localEnv:...}` placeholders, and pre-create the
 corresponding files or directories. This prevents Docker from failing when optional configuration files are absent
-locally while still allowing host ↔ container synchronization.
+locally while still allowing host ↔ container synchronization. The default Bash history mount now targets
+`${HOME}/.dev_con_bash_history`, avoiding conflicts with other Devcontainer workspaces that previously shared
+`~/.bash_history`.
 
 ## Lifecycle Scripts
 
@@ -57,7 +59,8 @@ locally while still allowing host ↔ container synchronization.
 
 - `on-create.sh` — runs on first container creation (npm updates, shell configuration).
 - `update-content.sh` — refreshes project dependencies and Playwright artifacts.
-- `post-create.sh` — post-provision hooks (if any).
+- `post-create.sh` — installs MCP extensions (`@upstash/context7-mcp`, `@playwright/mcp`, `github-mcp-server`) and the
+  Codex CLI so the container exposes the tooling required by the automation scripts without relying on host binaries.
 
 Shared logic (logging, devcontainer JSON helpers, package installers) lives in `scripts/common.sh`.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -16,6 +16,8 @@ Tags that include `-alpha.`, `-beta.`, or `-rc.` are published as prereleases. A
 
 > Note
 > Keep the top “Unreleased” section in `CHANGELOG.md` up‑to‑date before drafting the release. We use it as the release body.
+> The composer automatically appends the artifact inventory after the changelog excerpt so first-time releases still
+> include canonical download links.
 
 ## Artifact Inventory
 


### PR DESCRIPTION
## Summary
- enforce workflow concurrency with a shared `${{ github.workflow }}-${{ github.ref }}` group across every pipeline
- document the new concurrency behaviour, devcontainer history mount, and release-note composer updates
- refresh the changelog to capture release tooling and devcontainer changes while noting the claude installer removal

## Testing
- not run (docs and workflow updates only)
